### PR TITLE
fix(diff): skip colors when running git diff…

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,7 +26,7 @@ const SEVERITY_PROPS = {
   },
 }
 // Git commands
-const gitDiffBase = 'git diff --staged --diff-filter=ACM'
+const gitDiffBase = 'git diff --staged --diff-filter=ACM --no-color'
 // List added or updated file names only
 const gitStagedFiles = `${gitDiffBase} --name-only`
 // We don't use `git show :0:${file}` because we only want to


### PR DESCRIPTION
When color codes are used grepping on lines starting with `+` won’t work due to escaped color codes