### PR TITLE
feat(rules): load rules from scoped names…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Configuration is loaded from _package.json_ so you can customize it according to
 Here is an example :
 
 ```JSON
-"hooks": {
-  "pre-commit": [
+"git-precommit-checks": {
+  "rules": [
     {
       "filter": "\\.js$",
       "nonBlocking": "true",
@@ -58,14 +58,25 @@ Only `message` and `regex` keys are mandatory.
 
 ⚠️ _There is no default checks configured after install, so please be aware that nothing will happend without adding your own rules!_
 
-## Debug mode
+## Display options
 
-You can use the `--debug` option to print processing detail:
+You can add an optional `display` entry in your config to enable some options:
 
-- `package.json` path
-- loaded rules (printed as a table)
-- checked files
-- short summary/stats (errors and warnings number)
+```JSON
+"git-precommit-checks": {
+  "rules": {
+    "offending-content": true,
+    "rules-summary": true,
+    "short-stats": true,
+    "verbose": true
+  },
+  …
+```
+
+- `offending-content`: print offending contents rights after associated file path and line number
+- `rules-summary`: print rules as a table before parsing staged files
+- `short-stats`: print short stats (ie. `1 error, 1 warning.`)
+- `verbose`: print every performed action, files parsed, short summary/stats (errors and warnings number)
 
 ## Recommendations
 
@@ -80,3 +91,7 @@ You can use it and call `git-precommit-checks` on `pre-commit`:
     }
   }
 ```
+
+# Contributing
+
+Any contribution is welcomed. Here is our [contribution guideline](CONTRIBUTING.md)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,9 @@ const nodeExec = util.promisify(require('child_process').exec)
 // Configuration stuff
 const readPkgUp = require('read-pkg-up')
 
+// Used only for logging/debuggin
+var Table = require('cli-table')
+
 // Logs colors
 const SEVERITY_PROPS = {
   error: {
@@ -108,9 +111,9 @@ function getStagedContents(files) {
 }
 
 // Load configuration as JSON from closest package.json
-async function loadPackageJSON(debug) {
+async function loadPackageJSON(verbose) {
   const { pkg, path } = await readPkgUp()
-  if (debug) {
+  if (verbose) {
     console.log(`Loading configuration from "${path}"`)
   }
   return pkg
@@ -198,6 +201,19 @@ function printErrors({
   return true
 }
 
+// Print rules as table
+function printRulesSummary({ config, rules }) {
+  if (config.display && config.display['rules-summary']) {
+    const table = new Table({
+      head: ['Filter', 'Message', 'Blocking', 'Patter/regex'],
+    })
+    for (const { filter = '*', message, nonBlocking, regex } of rules) {
+      table.push([filter, message, !nonBlocking, regex.toString()])
+    }
+    console.log(`\n${table.toString()}\n`)
+  }
+}
+
 // Print a short summary of errors and warnings count.
 // Example: `3 errors, no warnings`
 function printSummary(warns, errs) {
@@ -243,6 +259,7 @@ module.exports = {
   loadPackageJSON,
   logAndExitWithTitle,
   parseStagedContent,
+  printRulesSummary,
   printErrors,
   printSummary,
   regexFromStr,

--- a/lib/utils.spec.js
+++ b/lib/utils.spec.js
@@ -123,7 +123,7 @@ describe('utils', () => {
 -warning: white
 +error: red
 +warning: yellow
-@@ -118,0 +120,49 @@ async function loadPackageJSON(debug) {
+@@ -118,0 +120,49 @@ async function loadPackageJSON() {
 +const LINE_HUNK_REGEX = /@@ -(\\d+)/
 +function parseStagedContent(content) {}
       `

--- a/package.json
+++ b/package.json
@@ -99,8 +99,14 @@
       "node": true
     }
   },
-  "hooks": {
-    "pre-commit": [
+  "git-precommit-checks": {
+    "display": {
+      "offending-content": true,
+      "rules-summary": false,
+      "short-stats": true,
+      "verbose": false
+    },
+    "rules": [
       {
         "message": "You’ve got leftover conflict markers",
         "regex": "/^[<>|=]{4,}/m"


### PR DESCRIPTION
Remove `debug` option. Add display options instead:

- `offending-content`: print offending contents rights after associated file path and line number
- `rules-summary`: print rules as a table before parsing staged files
- `short-stats`: print short stats (ie. `1 error, 1 warning.`)
- `verbose`: print every performed action, files parsed, short summary/stats (errors and warnings number)

Add dedicated section in README.

BREAKING CHANGE: moves previous configuration target from `hooks` to
`git-precommit-checks`.
Previous name was too generic, we needed a more "scoped" name.

Closes #15