### PR TITLE
Update example rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Here is an example :
       "regex": "/^[<>|=]{4,}/m"
     },
     {
+      "filter": "package.json",
       "message": "You have unfinished devs",
       "nonBlocking": "true",
       "regex": "(?:FIXME|TODO)"


### PR DESCRIPTION
Last rule to check FIXME/TODO will always hit package.json unless you filter it out.